### PR TITLE
[bug] Allow spaces in the next cell in custom format

### DIFF
--- a/src/parse/custom_format_parser.ts
+++ b/src/parse/custom_format_parser.ts
@@ -11,7 +11,7 @@ export async function isContactFile(
 
 export async function parseContactData(file: TFile, vault: Vault): Promise<Contact | null> {
   const fileContents = await vault.cachedRead(file);
-  const regexpNames = /^\|(?<key>.+)\|(?<value>.+)\|$/gm;
+  const regexpNames = /^\|(?<key>.+)\|(?<value>.+)\|(\s)*$/gm;
   const contactsDict: { [key: string]: string } = {};
   for (const match of fileContents.matchAll(regexpNames)) {
     if (!match.groups) {


### PR DESCRIPTION
If the contact file contains space in the next cell it can't be parsed, for example:
```
/---contact---/
| key       | value                     |
| --------- | ------------------------- |
| Birthday  | 1995-10-20                |␣
/---contact---/
```
For such contact, `birthday` will not be displayed.

This PR changes regexp to handle such cases.
